### PR TITLE
Extract union attribute generation

### DIFF
--- a/src/Dunet/GenerateUnionAttribute/UnionAttributeGenerator.cs
+++ b/src/Dunet/GenerateUnionAttribute/UnionAttributeGenerator.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+using System.Text;
+
+namespace Dunet.UnionAttributeGeneration;
+
+[Generator]
+public class UnionAttributeGenerator : IIncrementalGenerator
+{
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        context.RegisterPostInitializationOutput(
+            ctx =>
+                ctx.AddSource(
+                    "UnionAttribute.g.cs",
+                    SourceText.From(UnionAttributeSource.Attribute, Encoding.UTF8)
+                )
+        );
+    }
+}

--- a/src/Dunet/GenerateUnionAttribute/UnionAttributeSource.cs
+++ b/src/Dunet/GenerateUnionAttribute/UnionAttributeSource.cs
@@ -1,4 +1,4 @@
-﻿namespace Dunet;
+﻿namespace Dunet.UnionAttributeGeneration;
 
 internal class UnionAttributeSource
 {

--- a/src/Dunet/GenerateUnionInterface/AccessibilityExtensions.cs
+++ b/src/Dunet/GenerateUnionInterface/AccessibilityExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.CodeAnalysis;
 
-namespace Dunet;
+namespace Dunet.GenerateUnionInterface;
 
 internal static class AccessibilityExtensions
 {

--- a/src/Dunet/GenerateUnionInterface/IdentifierExtensions.cs
+++ b/src/Dunet/GenerateUnionInterface/IdentifierExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace Dunet;
+﻿namespace Dunet.GenerateUnionInterface;
 
 internal static class IdentifierExtensions
 {

--- a/src/Dunet/GenerateUnionInterface/MatchMethodToGenerate.cs
+++ b/src/Dunet/GenerateUnionInterface/MatchMethodToGenerate.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.CodeAnalysis;
 
-namespace Dunet.UnionInterface;
+namespace Dunet.GenerateUnionInterface;
 
 record MatchMethodToGenerate(
     List<string> Imports,

--- a/src/Dunet/GenerateUnionInterface/RecordToGenerate.cs
+++ b/src/Dunet/GenerateUnionInterface/RecordToGenerate.cs
@@ -1,4 +1,4 @@
-﻿namespace Dunet;
+﻿namespace Dunet.GenerateUnionInterface;
 
 record RecordToGenerate(
     List<string> Imports,

--- a/src/Dunet/GenerateUnionInterface/UnionInterfaceGenerator.cs
+++ b/src/Dunet/GenerateUnionInterface/UnionInterfaceGenerator.cs
@@ -1,4 +1,4 @@
-﻿using Dunet.UnionInterface;
+﻿using Dunet.UnionAttributeGeneration;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -6,21 +6,13 @@ using Microsoft.CodeAnalysis.Text;
 using System.Collections.Immutable;
 using System.Text;
 
-namespace Dunet;
+namespace Dunet.GenerateUnionInterface;
 
 [Generator]
 public class UnionInterfaceGenerator : IIncrementalGenerator
 {
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
-        context.RegisterPostInitializationOutput(
-            ctx =>
-                ctx.AddSource(
-                    "UnionAttribute.g.cs",
-                    SourceText.From(UnionAttributeSource.Attribute, Encoding.UTF8)
-                )
-        );
-
         var interfaceDeclarations = context.SyntaxProvider
             .CreateSyntaxProvider(
                 predicate: static (node, _) => node.IsDecoratedInterface(),

--- a/src/Dunet/GenerateUnionInterface/UnionInterfaceSource.cs
+++ b/src/Dunet/GenerateUnionInterface/UnionInterfaceSource.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text;
 
-namespace Dunet.UnionInterface;
+namespace Dunet.GenerateUnionInterface;
 
 internal static class UnionInterfaceSource
 {

--- a/src/Dunet/GenerateUnionRecord/UnionRecord.cs
+++ b/src/Dunet/GenerateUnionRecord/UnionRecord.cs
@@ -1,4 +1,4 @@
-﻿namespace Dunet.UnionRecord;
+﻿namespace Dunet.GenerateUnionRecord;
 
 internal record UnionRecord(
     List<string> Imports,

--- a/src/Dunet/GenerateUnionRecord/UnionRecordGenerator.cs
+++ b/src/Dunet/GenerateUnionRecord/UnionRecordGenerator.cs
@@ -1,4 +1,4 @@
-﻿using Dunet.UnionInterface;
+﻿using Dunet.UnionAttributeGeneration;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.Text;
 using System.Collections.Immutable;
 using System.Text;
 
-namespace Dunet.UnionRecord;
+namespace Dunet.GenerateUnionRecord;
 
 [Generator]
 public class UnionRecordGenerator : IIncrementalGenerator

--- a/src/Dunet/GenerateUnionRecord/UnionRecordSource.cs
+++ b/src/Dunet/GenerateUnionRecord/UnionRecordSource.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text;
 
-namespace Dunet.UnionRecord;
+namespace Dunet.GenerateUnionRecord;
 
 internal static class UnionRecordSource
 {

--- a/src/Dunet/SyntaxExtensions.cs
+++ b/src/Dunet/SyntaxExtensions.cs
@@ -4,7 +4,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Dunet;
 
-public static class SyntaxExtensions
+internal static class SyntaxExtensions
 {
     public static IEnumerable<MethodDeclarationSyntax> GetMethodDeclarations(
         this TypeDeclarationSyntax typeDeclaration

--- a/src/Dunet/UnionRecord/UnionRecordGenerator.cs
+++ b/src/Dunet/UnionRecord/UnionRecordGenerator.cs
@@ -13,14 +13,6 @@ public class UnionRecordGenerator : IIncrementalGenerator
 {
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
-        context.RegisterPostInitializationOutput(
-            ctx =>
-                ctx.AddSource(
-                    "UnionAttribute.g.cs",
-                    SourceText.From(UnionAttributeSource.Attribute, Encoding.UTF8)
-                )
-        );
-
         var recordDeclarations = context.SyntaxProvider
             .CreateSyntaxProvider(
                 predicate: static (node, _) => node.IsDecoratedRecord(),

--- a/test/Dunet.Test/Compiler/Compile.cs
+++ b/test/Dunet.Test/Compiler/Compile.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using Dunet.UnionAttributeGeneration;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using System.Reflection;
 
@@ -6,6 +7,9 @@ namespace Dunet.Test.Compiler;
 
 public class Compile
 {
+    private static readonly IIncrementalGenerator unionAttributeGenerator =
+        new UnionAttributeGenerator();
+
     private readonly IIncrementalGenerator generator;
 
     public Compile(IIncrementalGenerator generator) => this.generator = generator;
@@ -40,7 +44,7 @@ public class Compile
     private GenerationResult RunGenerator(Compilation compilation)
     {
         CSharpGeneratorDriver
-            .Create(generator)
+            .Create(generator, unionAttributeGenerator)
             .RunGeneratorsAndUpdateCompilation(
                 compilation,
                 out var outputCompilation,

--- a/test/Dunet.Test/UnionInterface/UnionInterfaceTests.cs
+++ b/test/Dunet.Test/UnionInterface/UnionInterfaceTests.cs
@@ -1,4 +1,5 @@
-﻿using Dunet.Test.Compiler;
+﻿using Dunet.GenerateUnionInterface;
+using Dunet.Test.Compiler;
 
 namespace Dunet.Test.UnionInterface;
 

--- a/test/Dunet.Test/UnionRecord/UnionRecordTests.cs
+++ b/test/Dunet.Test/UnionRecord/UnionRecordTests.cs
@@ -1,5 +1,5 @@
 ﻿using Dunet.Test.Compiler;
-using Dunet.UnionRecord;
+using Dunet.GenerateUnionRecord;
 
 namespace Dunet.Test.UnionRecord;
 


### PR DESCRIPTION
- Move union attribute generation to its own namespace.
- Reorganize other namespaces.