### PR TITLE
Add support for factory method generation

### DIFF
--- a/Dunet.sln
+++ b/Dunet.sln
@@ -21,6 +21,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PokemonClient", "samples\Po
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExpressionCalculator", "samples\ExpressionCalculator\ExpressionCalculator.csproj", "{E48DBF5C-52AA-490C-988A-FF191C8CA4B9}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{B27F5AB4-D18C-4B5F-9A9F-5265DADF2F14}"
+	ProjectSection(SolutionItems) = preProject
+		favicon.png = favicon.png
+		License.txt = License.txt
+		Readme.md = Readme.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/Readme.md
+++ b/Readme.md
@@ -32,6 +32,32 @@ var area = shape.Match(
 Console.WriteLine(area); // "12"
 ```
 
+### Configuration
+
+Dunet can be configured by setting `Dunet_*` properties in your project file:
+
+```xml
+<PropertyGroup>
+  <Dunet_GenerateFactoryMethods>true</Dunet_GenerateFactoryMethods>
+  <Dunet_FactoryMethodPrefix>Create</Dunet_FactoryMethodPrefix>
+  <Dunet_FactoryMethodSuffix>Now</Dunet_FactoryMethodSuffix>
+</PropertyGroup>
+```
+
+Overrides to project defaults can be set by setting properties on `UnionAttribute`:
+
+```cs
+[Union(GenerateFactoryMethods=true, FactoryMethodPrefix="Create", FactoryMethodSuffix="Now")]
+partial record Shape
+{
+    partial record Circle(double Radius);
+    partial record Rectangle(double Length, double Width);
+}
+
+var circle = Shape.CreateCircleNow(7);
+```
+
+
 ## Generics Support
 
 Use generics for more advanced union types. For example, an option monad:

--- a/src/Dunet.csproj
+++ b/src/Dunet.csproj
@@ -37,6 +37,7 @@
 
     <ItemGroup>
         <None Include="$(OutputPath)/$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+        <None Include="Dunet.props" Pack="true" PackagePath="build/netstandard2.0" />
     </ItemGroup>
 
     <ItemGroup>
@@ -49,7 +50,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" />
     </ItemGroup>
 
 </Project>

--- a/src/Dunet.props
+++ b/src/Dunet.props
@@ -1,0 +1,12 @@
+<Project>
+  <PropertyGroup>
+    <Dunet_GenerateFactoryMethods Condition=" '$(Dunet_GenerateFactoryMethods)' == '' ">false</Dunet_GenerateFactoryMethods>
+    <Dunet_FactoryMethodPrefix Condition=" '$(Dunet_FactoryMethodPrefix)' == '' ">New</Dunet_FactoryMethodPrefix>
+    <Dunet_FactoryMethodSuffix Condition=" '$(Dunet_FactoryMethodSuffix)' == '' "></Dunet_FactoryMethodSuffix>
+  </PropertyGroup>
+  <ItemGroup>
+    <CompilerVisibleProperty Include="Dunet_GenerateFactoryMethods" />
+    <CompilerVisibleProperty Include="Dunet_FactoryMethodPrefix" />
+    <CompilerVisibleProperty Include="Dunet_FactoryMethodSuffix" />
+  </ItemGroup>
+</Project>

--- a/src/GenerateUnionAttribute/UnionAttributeGenerator.cs
+++ b/src/GenerateUnionAttribute/UnionAttributeGenerator.cs
@@ -12,7 +12,7 @@ public class UnionAttributeGenerator : IIncrementalGenerator
         context.RegisterPostInitializationOutput(
             ctx =>
                 ctx.AddSource(
-                    "UnionAttribute.g.cs",
+                    $"{UnionAttributeSource.AttributeName}.g.cs",
                     SourceText.From(UnionAttributeSource.Attribute, Encoding.UTF8)
                 )
         );

--- a/src/GenerateUnionAttribute/UnionAttributeOptions.cs
+++ b/src/GenerateUnionAttribute/UnionAttributeOptions.cs
@@ -1,31 +1,56 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Dunet.UnionAttributeGeneration;
 
 record UnionAttributeOptions(bool GenerateFactoryMethods, string FactoryMethodPrefix, string FactoryMethodSuffix)
 {
-    public static readonly UnionAttributeOptions Default = new(true, "New", "");
+    public static UnionAttributeOptions CreateDefault(AnalyzerConfigOptionsProvider configOptions)
+    {
+        if (!configOptions.GlobalOptions.TryGetValue("build_property.Dunet_GenerateFactoryMethods",
+                out var generateFactoryMethodsStr)
+            || !bool.TryParse(generateFactoryMethodsStr, out var generateFactoryMethods))
+        {
+            throw new Exception($"Dunet_GenerateFactoryMethods MSBuild property must be either true or false.  Actual: {generateFactoryMethodsStr}");
+        }
 
-    public UnionAttributeOptions WithAttributeArgument(GeneratorSyntaxContext context,
+        if (!configOptions.GlobalOptions.TryGetValue("build_property.Dunet_FactoryMethodPrefix",
+                out var factoryMethodPrefix))
+        {
+            throw new Exception("Dunet_FactoryMethodPrefix MSBuild property missing");
+        }
+        factoryMethodPrefix = factoryMethodPrefix.Trim();
+
+        if (!configOptions.GlobalOptions.TryGetValue("build_property.Dunet_FactoryMethodSuffix",
+                out var factoryMethodSuffix))
+        {
+            throw new Exception("Dunet_FactoryMethodSuffix MSBuild property missing");
+        }
+        factoryMethodSuffix = factoryMethodSuffix.Trim();
+
+        return new UnionAttributeOptions(generateFactoryMethods, factoryMethodPrefix, factoryMethodSuffix);
+    }
+
+    public UnionAttributeOptions WithAttributeArgument(SemanticModel semanticModel,
         AttributeArgumentSyntax argument)
     {
-        if (context.SemanticModel.GetConstantValue(argument.Expression) is not { HasValue: true, Value: {} propertyValue })
+        if (semanticModel.GetConstantValue(argument.Expression) is not { HasValue: true, Value: { } propertyValue })
             return this;
 
         return argument.NameEquals?.Name.Identifier.Text switch
         {
             nameof(GenerateFactoryMethods) => this with
             {
-                GenerateFactoryMethods = (bool) propertyValue
+                GenerateFactoryMethods = (bool)propertyValue
             },
             nameof(FactoryMethodPrefix) => this with
             {
-                FactoryMethodPrefix = (string) propertyValue
+                FactoryMethodPrefix = (string)propertyValue
             },
             nameof(FactoryMethodSuffix) => this with
             {
-                FactoryMethodSuffix = (string) propertyValue
+                FactoryMethodSuffix = (string)propertyValue
             },
             null => this,
             // Unreachable

--- a/src/GenerateUnionAttribute/UnionAttributeOptions.cs
+++ b/src/GenerateUnionAttribute/UnionAttributeOptions.cs
@@ -1,0 +1,35 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Dunet.UnionAttributeGeneration;
+
+record UnionAttributeOptions(bool GenerateFactoryMethods, string FactoryMethodPrefix, string FactoryMethodSuffix)
+{
+    public static readonly UnionAttributeOptions Default = new(true, "New", "");
+
+    public UnionAttributeOptions WithAttributeArgument(GeneratorSyntaxContext context,
+        AttributeArgumentSyntax argument)
+    {
+        if (context.SemanticModel.GetConstantValue(argument.Expression) is not { HasValue: true, Value: {} propertyValue })
+            return this;
+
+        return argument.NameEquals?.Name.Identifier.Text switch
+        {
+            nameof(GenerateFactoryMethods) => this with
+            {
+                GenerateFactoryMethods = (bool) propertyValue
+            },
+            nameof(FactoryMethodPrefix) => this with
+            {
+                FactoryMethodPrefix = (string) propertyValue
+            },
+            nameof(FactoryMethodSuffix) => this with
+            {
+                FactoryMethodSuffix = (string) propertyValue
+            },
+            null => this,
+            // Unreachable
+            _ => throw new ArgumentOutOfRangeException()
+        };
+    }
+}

--- a/src/GenerateUnionAttribute/UnionAttributeSource.cs
+++ b/src/GenerateUnionAttribute/UnionAttributeSource.cs
@@ -6,11 +6,16 @@ internal class UnionAttributeSource
     public const string AttributeName = "UnionAttribute";
     public const string FullAttributeName = $"{AttributeNamespace}.{AttributeName}";
 
-    public const string Attribute =
-        @"using System;
+    public static readonly string Attribute =
+        $@"using System;
 
 namespace Dunet;
 
 [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
-public sealed class UnionAttribute : Attribute {}";
+public sealed class UnionAttribute : Attribute
+{{
+    public bool GenerateFactoryMethods {{ get; set; }} = {UnionAttributeOptions.Default.GenerateFactoryMethods.ToString().ToLowerInvariant()};
+    public string FactoryMethodPrefix {{ get; set; }} = ""{UnionAttributeOptions.Default.FactoryMethodPrefix}"";
+    public string FactoryMethodSuffix {{ get; set; }} = ""{UnionAttributeOptions.Default.FactoryMethodSuffix}"";
+}}";
 }

--- a/src/GenerateUnionAttribute/UnionAttributeSource.cs
+++ b/src/GenerateUnionAttribute/UnionAttributeSource.cs
@@ -9,13 +9,30 @@ internal class UnionAttributeSource
     public static readonly string Attribute =
         $@"using System;
 
-namespace Dunet;
+namespace {AttributeNamespace};
 
 [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
-public sealed class UnionAttribute : Attribute
+public sealed partial class {AttributeName} : Attribute
 {{
-    public bool GenerateFactoryMethods {{ get; set; }} = {UnionAttributeOptions.Default.GenerateFactoryMethods.ToString().ToLowerInvariant()};
-    public string FactoryMethodPrefix {{ get; set; }} = ""{UnionAttributeOptions.Default.FactoryMethodPrefix}"";
-    public string FactoryMethodSuffix {{ get; set; }} = ""{UnionAttributeOptions.Default.FactoryMethodSuffix}"";
+}}";
+
+    public static string GetPropertySource(UnionAttributeOptions defaultOptions) =>
+        $@"using System;
+
+namespace {AttributeNamespace};
+
+public partial class {AttributeName}
+{{
+    /// Whether to generate static factory methods.
+    /// Default: <c>{defaultOptions.GenerateFactoryMethods.ToString().ToLowerInvariant()}</c> 
+    public bool GenerateFactoryMethods {{ get; set; }} = {defaultOptions.GenerateFactoryMethods.ToString().ToLowerInvariant()};
+
+    /// Prefix for factory method names.
+    /// Default: ""{defaultOptions.FactoryMethodPrefix}""
+    public string FactoryMethodPrefix {{ get; set; }} = ""{defaultOptions.FactoryMethodPrefix}"";
+
+    /// Suffix for factory method names.
+    /// Default: ""{defaultOptions.FactoryMethodSuffix}""
+    public string FactoryMethodSuffix {{ get; set; }} = ""{defaultOptions.FactoryMethodSuffix}"";
 }}";
 }

--- a/src/GenerateUnionRecord/UnionRecord.cs
+++ b/src/GenerateUnionRecord/UnionRecord.cs
@@ -1,11 +1,14 @@
-﻿namespace Dunet.GenerateUnionRecord;
+﻿using Dunet.UnionAttributeGeneration;
+
+namespace Dunet.GenerateUnionRecord;
 
 internal record UnionRecord(
     List<string> Imports,
     string? Namespace,
     string Name,
     List<TypeParameter> TypeParameters,
-    List<UnionRecordMember> Members
+    List<UnionRecordMember> Members,
+    UnionAttributeOptions Options
 );
 
 internal record UnionRecordMember(

--- a/src/GenerateUnionRecord/UnionRecordSource.cs
+++ b/src/GenerateUnionRecord/UnionRecordSource.cs
@@ -25,6 +25,29 @@ internal static class UnionRecordSource
         builder.AppendLine($"    private {record.Name}() {{}}");
         builder.AppendLine();
 
+        if (record.Options.GenerateFactoryMethods)
+        {
+            foreach (var member in record.Members)
+            {
+                var parameterList = string.Join(", ",
+                    member.Properties.Select(p => $"{p.Type} {p.Name.ToMethodParameterCase()}"));
+                builder.Append($"    public static {record.Name}");
+                builder.AppendTypeParams(record.TypeParameters);
+                builder.Append(
+                    $" {record.Options.FactoryMethodPrefix}{member.Name}{record.Options.FactoryMethodSuffix}");
+                builder.AppendTypeParams(member.TypeParameters);
+                builder.AppendLine($"({parameterList}) =>");
+
+                var constructorArgList =
+                    string.Join(", ", member.Properties.Select(p => p.Name.ToMethodParameterCase()));
+                builder.Append($"        new {member.Name}");
+                builder.AppendTypeParams(member.TypeParameters);
+                builder.AppendLine($"({constructorArgList});");
+            }
+
+            builder.AppendLine();
+        }
+
         builder.AppendLine("    public abstract TMatchOutput Match<TMatchOutput>(");
         for (int i = 0; i < record.Members.Count; ++i)
         {

--- a/test/Compiler/AnalyzerConfigOptions.cs
+++ b/test/Compiler/AnalyzerConfigOptions.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Dunet.Test.Compiler;
 
-class DictionaryAnalyzerConfigOptions : AnalyzerConfigOptions
+public class DictionaryAnalyzerConfigOptions : AnalyzerConfigOptions
 {
     public static DictionaryAnalyzerConfigOptions Empty { get; } = new(ImmutableDictionary.Create<string, string>(KeyComparer));
 
@@ -18,16 +18,16 @@ class DictionaryAnalyzerConfigOptions : AnalyzerConfigOptions
         => Options.TryGetValue(key, out value);
 }
 
-class DictionaryAnalyzerConfigOptionsProvider : AnalyzerConfigOptionsProvider
+public class DictionaryAnalyzerConfigOptionsProvider : AnalyzerConfigOptionsProvider
 {
     public static DictionaryAnalyzerConfigOptionsProvider Empty { get; } = new(DictionaryAnalyzerConfigOptions.Empty);
 
-    internal DictionaryAnalyzerConfigOptionsProvider(AnalyzerConfigOptions globalOptions)
+    internal DictionaryAnalyzerConfigOptionsProvider(DictionaryAnalyzerConfigOptions globalOptions)
     {
         GlobalOptions = globalOptions;
     }
 
-    public override AnalyzerConfigOptions GlobalOptions { get; }
+    public override DictionaryAnalyzerConfigOptions GlobalOptions { get; }
 
     public override AnalyzerConfigOptions GetOptions(SyntaxTree tree)
         => DictionaryAnalyzerConfigOptions.Empty;

--- a/test/Compiler/AnalyzerConfigOptions.cs
+++ b/test/Compiler/AnalyzerConfigOptions.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Dunet.Test.Compiler;
+
+class DictionaryAnalyzerConfigOptions : AnalyzerConfigOptions
+{
+    public static DictionaryAnalyzerConfigOptions Empty { get; } = new(ImmutableDictionary.Create<string, string>(KeyComparer));
+
+    public ImmutableDictionary<string, string> Options { get; }
+
+    public DictionaryAnalyzerConfigOptions(ImmutableDictionary<string, string> options)
+        => Options = options;
+
+    public override bool TryGetValue(string key, [NotNullWhen(true)] out string? value)
+        => Options.TryGetValue(key, out value);
+}
+
+class DictionaryAnalyzerConfigOptionsProvider : AnalyzerConfigOptionsProvider
+{
+    public static DictionaryAnalyzerConfigOptionsProvider Empty { get; } = new(DictionaryAnalyzerConfigOptions.Empty);
+
+    internal DictionaryAnalyzerConfigOptionsProvider(AnalyzerConfigOptions globalOptions)
+    {
+        GlobalOptions = globalOptions;
+    }
+
+    public override AnalyzerConfigOptions GlobalOptions { get; }
+
+    public override AnalyzerConfigOptions GetOptions(SyntaxTree tree)
+        => DictionaryAnalyzerConfigOptions.Empty;
+
+    public override AnalyzerConfigOptions GetOptions(AdditionalText textFile)
+        => DictionaryAnalyzerConfigOptions.Empty;
+}

--- a/test/GenerateUnionRecord/FactoryMethodTests.cs
+++ b/test/GenerateUnionRecord/FactoryMethodTests.cs
@@ -1,0 +1,89 @@
+﻿namespace Dunet.Test.GenerateUnionRecord;
+
+public class FactoryMethodTests : UnionRecordTests
+{
+    [Fact]
+    public void FactoryMethodsAreGeneratedByDefault()
+    {
+        // Arrange.
+        var programCs =
+            @"
+using Dunet;
+
+ComplexUnion<int> generic = ComplexUnion<int>.NewGenericCase(15, ""Hello"");
+ComplexUnion<int> argless = ComplexUnion<int>.NewArgless();
+ComplexUnion<int> recursive = ComplexUnion<int>.NewRecursiveCase(generic);
+
+[Union]
+partial record ComplexUnion<T>
+{
+    partial record GenericCase(T Generic, string Test);
+    partial record Argless();
+    partial record RecursiveCase(ComplexUnion<T> Inner);
+}";
+
+        // Act.
+        var result = Compile.ToAssembly(programCs);
+
+        // Assert.
+        result.CompilationErrors.Should().BeEmpty();
+        result.GenerationDiagnostics.Should().BeEmpty();
+    }
+    
+    [Fact]
+    public void FactoryMethodGenerationCanBeCustomised()
+    {
+        // Arrange.
+        var programCs =
+            @"
+using Dunet;
+
+ComplexUnion<int> generic = ComplexUnion<int>.MakeGenericCaseNow(15, ""Hello"");
+ComplexUnion<int> argless = ComplexUnion<int>.MakeArglessNow();
+ComplexUnion<int> recursive = ComplexUnion<int>.MakeRecursiveCaseNow(generic);
+
+[Union(FactoryMethodPrefix = ""Make"", FactoryMethodSuffix = ""Now"")]
+partial record ComplexUnion<T>
+{
+    partial record GenericCase(T Generic, string Test);
+    partial record Argless();
+    partial record RecursiveCase(ComplexUnion<T> Inner);
+}";
+
+        // Act.
+        var result = Compile.ToAssembly(programCs);
+
+        // Assert.
+        result.CompilationErrors.Should().BeEmpty();
+        result.GenerationDiagnostics.Should().BeEmpty();
+    }
+    
+    [Fact]
+    public void FactoryMethodGenerationCanBeDisabled()
+    {
+        // Arrange.
+        var programCs =
+            @"
+using Dunet;
+
+ComplexUnion<int> generic = ComplexUnion<int>.NewGenericCase(15, ""Hello"");
+ComplexUnion<int> argless = ComplexUnion<int>.NewArgless();
+ComplexUnion<int> recursive = ComplexUnion<int>.NewRecursiveCase(generic);
+
+[Union(GenerateFactoryMethods = false)]
+partial record ComplexUnion<T>
+{
+    partial record GenericCase(T Generic, string Test);
+    partial record Argless();
+    partial record RecursiveCase(ComplexUnion<T> Inner);
+}";
+
+        // Act.
+        var result = Compile.ToAssembly(programCs);
+
+        // Assert.
+        result.CompilationErrors.Should().HaveCount(3);
+        result.CompilationErrors.Should().AllSatisfy(diagnostic => diagnostic.Id.Should().Be("CS0117"));
+        result.GenerationDiagnostics.Should().BeEmpty();
+    }
+}

--- a/test/GenerateUnionRecord/FactoryMethodTests.cs
+++ b/test/GenerateUnionRecord/FactoryMethodTests.cs
@@ -68,6 +68,38 @@ partial record ComplexUnion<T>
     }
 
     [Fact]
+    public void FactoryMethodGenerationCanBeEnabledByBuildProperty()
+    {
+        // Arrange.
+        var programCs =
+            @"
+using Dunet;
+
+ComplexUnion<int> generic = ComplexUnion<int>.MakeGenericCaseNow(15, ""Hello"");
+ComplexUnion<int> argless = ComplexUnion<int>.MakeArglessNow();
+ComplexUnion<int> recursive = ComplexUnion<int>.MakeRecursiveCaseNow(generic);
+
+[Union]
+partial record ComplexUnion<T>
+{
+    partial record GenericCase(T Generic, string Test);
+    partial record Argless();
+    partial record RecursiveCase(ComplexUnion<T> Inner);
+}";
+        var options = Compile.DefaultGlobalConfig
+            .SetItem("build_property.Dunet_GenerateFactoryMethods", "true")
+            .SetItem("build_property.Dunet_FactoryMethodPrefix", "Make")
+            .SetItem("build_property.Dunet_FactoryMethodSuffix", "Now");
+
+        // Act.
+        var result = Compile.ToAssembly(options, programCs);
+
+        // Assert.
+        result.CompilationErrors.Should().BeEmpty();
+        result.GenerationDiagnostics.Should().BeEmpty();
+    }
+
+    [Fact]
     public void FactoryMethodGenerationCanBeDisabled()
     {
         // Arrange.
@@ -84,9 +116,10 @@ partial record ComplexUnion<T>
     partial record Argless();
     partial record RecursiveCase(ComplexUnion<T> Inner);
 }";
+        var options = Compile.DefaultGlobalConfig.SetItem("build_property.Dunet_GenerateFactoryMethods", "true");
 
         // Act.
-        var result = Compile.ToAssembly(programCs);
+        var result = Compile.ToAssembly(options, programCs);
 
         // Assert.
         result.CompilationErrors.Should().BeEmpty();

--- a/test/GenerateUnionRecord/GenerationTests.cs
+++ b/test/GenerateUnionRecord/GenerationTests.cs
@@ -11,8 +11,11 @@ public class GenerationTests : UnionRecordTests
 using Dunet;
 
 QueryState loading = new QueryState.Loading();
+QueryState loadingFactory = QueryState.NewLoading();
 QueryState success = new QueryState.Success();
+QueryState successFactory = QueryState.NewSuccess();
 QueryState error = new QueryState.Error();
+QueryState errorFactory = QueryState.NewError();
 
 [Union]
 partial record QueryState
@@ -169,6 +172,33 @@ var failure = new Result.Failure(new Exception(""bar""));
 
         // Assert.
         result.CompilationErrors.Should().BeEmpty();
+        result.GenerationDiagnostics.Should().BeEmpty();
+    }
+    
+    [Fact]
+    public void FactoryMethodGenerationCanBeDisabled()
+    {
+        // Arrange.
+        var programCs =
+            @"
+using Dunet;
+
+QueryState loading = QueryState.NewLoading();
+
+[Union(GenerateFactoryMethods = false)]
+partial record QueryState
+{
+    partial record Loading();
+    partial record Success();
+    partial record Error();
+}";
+
+        // Act.
+        var result = Compile.ToAssembly(programCs);
+
+        // Assert.
+        result.CompilationErrors.Should().HaveCount(1);
+        result.CompilationErrors[0].Id.Should().Be("CS0117"); // error CS0117: 'QueryState' does not contain a definition for 'NewLoading'
         result.GenerationDiagnostics.Should().BeEmpty();
     }
 }

--- a/test/GenerateUnionRecord/GenerationTests.cs
+++ b/test/GenerateUnionRecord/GenerationTests.cs
@@ -17,7 +17,7 @@ QueryState successFactory = QueryState.NewSuccess();
 QueryState error = new QueryState.Error();
 QueryState errorFactory = QueryState.NewError();
 
-[Union]
+[Union(GenerateFactoryMethods = true)]
 partial record QueryState
 {
     partial record Loading();


### PR DESCRIPTION
Adds properties to `UnionAttribute` to allow the user the customise factory method generation and the factory method name prefix/suffix.

Fixes https://github.com/domn1995/dunet/issues/12