### PR TITLE
Set the Dunet NuGet package to be a development dependency

### DIFF
--- a/src/Dunet.csproj
+++ b/src/Dunet.csproj
@@ -5,6 +5,7 @@
         <Nullable>enable</Nullable>
         <LangVersion>10.0</LangVersion>
         <IsPublishable>True</IsPublishable>
+        <IncludeBuildOutput>false</IncludeBuildOutput>
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
         <Authors>domn1995</Authors>
         <Company />
@@ -33,6 +34,7 @@
         <SignAssembly>False</SignAssembly>
         <Version>1.0.0</Version>
         <NeutralLanguage>en</NeutralLanguage>
+        <DevelopmentDependency>true</DevelopmentDependency>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Dunet.csproj
+++ b/src/Dunet.csproj
@@ -35,6 +35,7 @@
         <Version>1.0.0</Version>
         <NeutralLanguage>en</NeutralLanguage>
         <DevelopmentDependency>true</DevelopmentDependency>
+        <NoWarn>$(NoWarn);NU5128</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
- `IncludeBuildOutput=false`: Removes `lib/netstandard2.0/Dunet.dll` from the package. This shouldn't be referenced directly by consumers.
- `DevelopmentDependency=true`: Ensures reference is not transitively consumed by dependents. See https://github.com/NuGet/Home/wiki/DevelopmentDependency-support-for-PackageReference.