### PR TITLE
Exclude interfaces from implicit conversions

### DIFF
--- a/src/GenerateUnionRecord/UnionRecord.cs
+++ b/src/GenerateUnionRecord/UnionRecord.cs
@@ -29,7 +29,9 @@ internal record TypeParameter(string Name)
     public sealed override string ToString() => Name;
 }
 
-internal record RecordProperty(string Type, string Name);
+internal record RecordProperty(PropertyType Type, string Name);
+
+internal record PropertyType(string Name, bool IsInterface);
 
 /// <summary>
 /// Represents a parent type declaration that nests a union record.

--- a/src/GenerateUnionRecord/UnionRecordGenerator.cs
+++ b/src/GenerateUnionRecord/UnionRecordGenerator.cs
@@ -135,10 +135,16 @@ public class UnionRecordGenerator : IIncrementalGenerator
                 var typeParameters = memberRecordDeclaration.TypeParameterList?.Parameters
                     .Select(static typeParam => typeParam.Identifier.ToString())
                     .Select(static identifier => new TypeParameter(identifier));
+
                 var properties = memberRecordDeclaration.ParameterList?.Parameters.Select(
-                    static parameter =>
+                    parameter =>
                         new RecordProperty(
-                            Type: parameter.Type?.ToString() ?? "",
+                            Type: new PropertyType(
+                                Name: parameter.Type?.ToString() ?? "",
+                                IsInterface: parameter.Type is not null
+                                    && semanticModel.GetTypeInfo(parameter.Type).Type?.TypeKind
+                                        is TypeKind.Interface
+                            ),
                             Name: parameter.Identifier.ToString()
                         )
                 );

--- a/src/GenerateUnionRecord/UnionRecordGenerator.cs
+++ b/src/GenerateUnionRecord/UnionRecordGenerator.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 using System.Collections.Immutable;
+using System.Reflection.Metadata;
 using System.Text;
 
 namespace Dunet.GenerateUnionRecord;
@@ -141,9 +142,7 @@ public class UnionRecordGenerator : IIncrementalGenerator
                         new RecordProperty(
                             Type: new PropertyType(
                                 Name: parameter.Type?.ToString() ?? "",
-                                IsInterface: parameter.Type is not null
-                                    && semanticModel.GetTypeInfo(parameter.Type).Type?.TypeKind
-                                        is TypeKind.Interface
+                                IsInterface: parameter.Type.IsInterfaceType(semanticModel)
                             ),
                             Name: parameter.Identifier.ToString()
                         )

--- a/src/GenerateUnionRecord/UnionRecordSource.cs
+++ b/src/GenerateUnionRecord/UnionRecordSource.cs
@@ -76,7 +76,7 @@ internal static class UnionRecordSource
                 builder.Append($"    public static implicit operator {record.Name}");
                 builder.AppendTypeParams(record.TypeParameters);
                 builder.AppendLine(
-                    $"({member.Properties[0].Type} value) => new {member.Name}(value);"
+                    $"({member.Properties[0].Type.Name} value) => new {member.Name}(value);"
                 );
             }
             builder.AppendLine();
@@ -143,7 +143,13 @@ internal static class UnionRecordSource
     {
         var membersHaveSingleParameter = () =>
             union.Members.All(member => member.Properties.Count is 1);
-        var membersHaveUniqueTypes = () =>
+
+        var membersHaveNoInterfaceParameters = () =>
+            !union.Members
+                .SelectMany(member => member.Properties)
+                .Any(prop => prop.Type.IsInterface);
+
+        var membersHaveUniqueParameterTypes = () =>
         {
             var allPropertyTypes = union.Members
                 .SelectMany(member => member.Properties)
@@ -153,6 +159,8 @@ internal static class UnionRecordSource
             return allPropertyTypesCount == uniquePropertyTypesCount;
         };
 
-        return membersHaveSingleParameter() && membersHaveUniqueTypes();
+        return membersHaveSingleParameter()
+            && membersHaveNoInterfaceParameters()
+            && membersHaveUniqueParameterTypes();
     }
 }

--- a/src/SyntaxExtensions.cs
+++ b/src/SyntaxExtensions.cs
@@ -55,4 +55,8 @@ internal static class SyntaxExtensions
             Accessibility.NotApplicable => "",
             _ => "",
         };
+
+    public static bool IsInterfaceType(this TypeSyntax? typeSyntax, SemanticModel semanticModel) =>
+        typeSyntax is not null
+        && semanticModel.GetTypeInfo(typeSyntax).Type?.TypeKind is TypeKind.Interface;
 }

--- a/test/GenerateUnionRecord/ImplicitConversionTests.cs
+++ b/test/GenerateUnionRecord/ImplicitConversionTests.cs
@@ -105,4 +105,31 @@ partial record Result<TFailure, TSuccess>
         result.CompilationErrors.Should().BeEmpty();
         result.GenerationDiagnostics.Should().BeEmpty();
     }
+
+    [Fact]
+    public void ImplicitConversionsAreNotCreatedForInterfaceMembers()
+    {
+        var programCs =
+            @"
+using Dunet;
+using System;
+using System.Collections.Generic;
+using static Result<int>;
+
+Result<int> success = new Success(42);
+Result<int> error = new Failure(new string[] { ""Error 1"", ""Error 2"", ""Error 3"" });
+
+[Union]
+partial record Result<T>
+{
+    partial record Success(T Value);
+    partial record Failure(IEnumerable<string> Errors);
+}";
+        // Act.
+        var result = Compile.ToAssembly(programCs);
+
+        // Assert.
+        result.CompilationErrors.Should().BeEmpty();
+        result.GenerationDiagnostics.Should().BeEmpty();
+    }
 }


### PR DESCRIPTION
Closes #70 and allows union members with interface types now.