### PR TITLE
Match with state - fixes #121

### DIFF
--- a/src/UnionGeneration/UnionSourceBuilder.cs
+++ b/src/UnionGeneration/UnionSourceBuilder.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Net.NetworkInformation;
+using System.Text;
 
 namespace Dunet.UnionGeneration;
 
@@ -122,6 +123,51 @@ internal static class UnionSourceBuilder
         builder.AppendLine("    );");
         builder.AppendLine();
 
+        // public abstract TMatchOutput Match<TState, TMatchOutput>(
+        //     TState state,
+        //     System.Func<TState, UnionVariant1<T1, T2, ...>, TMatchOutput> @unionVariant1,
+        //     System.Func<TState, UnionVariant2<T1, T2, ...>, TMatchOutput> @unionVariant2,
+        //     ...
+        // );
+        builder.AppendLine("    public abstract TMatchOutput Match<TState, TMatchOutput>(");
+        builder.AppendLine("        TState state,");
+        for (int i = 0; i < union.Variants.Count; ++i)
+        {
+            var variant = union.Variants[i];
+            builder.Append($"        System.Func<TState, {variant.Identifier}");
+            builder.AppendTypeParams(variant.TypeParameters);
+            builder.Append($", TMatchOutput> {variant.Identifier.ToMethodParameterCase()}");
+            if (i < union.Variants.Count - 1)
+            {
+                builder.Append(",");
+            }
+            builder.AppendLine();
+        }
+        builder.AppendLine("    );");
+
+        // public abstract void Match<TState>(
+        //     TState state,
+        //     System.Action<TState, UnionVariant1<T1, T2, ...>> @unionVariant1,
+        //     System.Action<TState, UnionVariant2<T1, T2, ...>> @unionVariant2,
+        //     ...
+        // );
+        builder.AppendLine("    public abstract void Match<TState>(");
+        builder.AppendLine("        TState state,");
+        for (int i = 0; i < union.Variants.Count; ++i)
+        {
+            var variant = union.Variants[i];
+            builder.Append($"        System.Action<TState, {variant.Identifier}");
+            builder.AppendTypeParams(variant.TypeParameters);
+            builder.Append($"> {variant.Identifier.ToMethodParameterCase()}");
+            if (i < union.Variants.Count - 1)
+            {
+                builder.Append(",");
+            }
+            builder.AppendLine();
+        }
+        builder.AppendLine("    );");
+        builder.AppendLine();
+
         return builder;
     }
 
@@ -159,6 +205,42 @@ internal static class UnionSourceBuilder
             builder.AppendTypeParams(variant.TypeParameters);
             builder.AppendLine($"> {variant.Identifier.ToMethodParameterCase()},");
             builder.AppendLine($"        System.Action @else");
+            builder.AppendLine("    );");
+        }
+
+        builder.AppendLine();
+
+        foreach (var variant in union.Variants)
+        {
+            // public abstract TMatchOutput MatchSpecific<TState, TMatchOutput>(
+            //     TState state,
+            //     System.Func<TState, Specific<T1, T2, ...>, TMatchOutput> @specific,
+            //     System.Func<TState, TMatchOutput> @else
+            // );
+            builder.AppendLine($"    public abstract TMatchOutput Match{variant.Identifier}<TState, TMatchOutput>(");
+            builder.AppendLine("        TState state,");
+            builder.Append($"        System.Func<TState, {variant.Identifier}");
+            builder.AppendTypeParams(variant.TypeParameters);
+            builder.AppendLine($", TMatchOutput> {variant.Identifier.ToMethodParameterCase()},");
+            builder.AppendLine($"        System.Func<TState, TMatchOutput> @else");
+            builder.AppendLine("    );");
+        }
+
+        builder.AppendLine();
+
+        foreach (var variant in union.Variants)
+        {
+            // public abstract void MatchSpecific<TState>(
+            //     TState state,
+            //     System.Action<TState, Specific<T1, T2, ...>> @specific,
+            //     System.Action<TState> @else
+            // );
+            builder.AppendLine($"    public abstract void Match{variant.Identifier}<TState>(");
+            builder.AppendLine("        TState state,");
+            builder.Append($"        System.Action<TState, {variant.Identifier}");
+            builder.AppendTypeParams(variant.TypeParameters);
+            builder.AppendLine($"> {variant.Identifier.ToMethodParameterCase()},");
+            builder.AppendLine($"        System.Action<TState> @else");
             builder.AppendLine("    );");
         }
 
@@ -212,6 +294,50 @@ internal static class UnionSourceBuilder
             builder.AppendLine();
         }
         builder.AppendLine($"        ) => {variant.Identifier.ToMethodParameterCase()}(this);");
+
+        // public override TMatchOutput Match<TState, TMatchOutput>(
+        //     TState state,
+        //     System.Func<TState, UnionVariant1<T1, T2, ...>, TMatchOutput> @unionVariant1,
+        //     System.Func<TState, UnionVariant2<T1, T2, ...>, TMatchOutput> @unionVariant2,
+        //     ...
+        // ) => unionVariantX(state, this);
+        builder.AppendLine("        public override TMatchOutput Match<TState, TMatchOutput>(");
+        builder.AppendLine("            TState state,");
+        for (int i = 0; i < union.Variants.Count; ++i)
+        {
+            var variantParam = union.Variants[i];
+            builder.Append($"            System.Func<TState, {variantParam.Identifier}");
+            builder.AppendTypeParams(variantParam.TypeParameters);
+            builder.Append($", TMatchOutput> {variantParam.Identifier.ToMethodParameterCase()}");
+            if (i < union.Variants.Count - 1)
+            {
+                builder.Append(",");
+            }
+            builder.AppendLine();
+        }
+        builder.AppendLine($"        ) => {variant.Identifier.ToMethodParameterCase()}(state, this);");
+
+        // public override void Match<TState>(
+        //     TState state,
+        //     System.Action<TState, UnionVariant1<T1, T2, ...>> @unionVariant1,
+        //     System.Action<TState, UnionVariant2<T1, T2, ...>> @unionVariant2,
+        //     ...
+        // ) => unionVariantX(state, this);
+        builder.AppendLine("        public override void Match<TState>(");
+        builder.AppendLine("            TState state,");
+        for (int i = 0; i < union.Variants.Count; ++i)
+        {
+            var variantParam = union.Variants[i];
+            builder.Append($"            System.Action<TState, {variantParam.Identifier}");
+            builder.AppendTypeParams(variantParam.TypeParameters);
+            builder.Append($"> {variantParam.Identifier.ToMethodParameterCase()}");
+            if (i < union.Variants.Count - 1)
+            {
+                builder.Append(",");
+            }
+            builder.AppendLine();
+        }
+        builder.AppendLine($"        ) => {variant.Identifier.ToMethodParameterCase()}(state, this);");
 
         return builder;
     }
@@ -269,6 +395,60 @@ internal static class UnionSourceBuilder
             else
             {
                 builder.AppendLine("@else();");
+            }
+        }
+
+        // public override TMatchOutput MatchVariantX<TState, TMatchOutput>(
+        //     TState state,
+        //     System.Func<TState, UnionVariant1<T1, T2, ...>, TMatchOutput> @unionVariantX,
+        //     System.Func<TState, TMatchOutput> @else,
+        //     ...
+        // ) => unionVariantX(state, this);
+        foreach (var specificVariant in union.Variants)
+        {
+            builder.AppendLine(
+                $"        public override TMatchOutput Match{specificVariant.Identifier}<TState, TMatchOutput>("
+            );
+            builder.AppendLine("            TState state,");
+            builder.Append($"            System.Func<TState, {specificVariant.Identifier}");
+            builder.AppendTypeParams(specificVariant.TypeParameters);
+            builder.AppendLine(
+                $", TMatchOutput> {specificVariant.Identifier.ToMethodParameterCase()},"
+            );
+            builder.AppendLine($"            System.Func<TState, TMatchOutput> @else");
+            builder.Append("        ) => ");
+            if (specificVariant.Identifier == variant.Identifier)
+            {
+                builder.AppendLine($"{specificVariant.Identifier.ToMethodParameterCase()}(state, this);");
+            }
+            else
+            {
+                builder.AppendLine("@else(state);");
+            }
+        }
+
+        // public override void MatchVariantX<TState>(
+        //     TState state,
+        //     System.Action<TState, UnionVariant1<T1, T2, ...>> @unionVariantX,
+        //     System.Action<TState> @else,
+        //     ...
+        // ) => unionVariantX(state, this);
+        foreach (var specificVariant in union.Variants)
+        {
+            builder.AppendLine($"        public override void Match{specificVariant.Identifier}<TState>(");
+            builder.AppendLine("            TState state,");
+            builder.Append($"            System.Action<TState, {specificVariant.Identifier}");
+            builder.AppendTypeParams(specificVariant.TypeParameters);
+            builder.AppendLine($"> {specificVariant.Identifier.ToMethodParameterCase()},");
+            builder.AppendLine($"            System.Action<TState> @else");
+            builder.Append("        ) => ");
+            if (specificVariant.Identifier == variant.Identifier)
+            {
+                builder.AppendLine($"{specificVariant.Identifier.ToMethodParameterCase()}(state, this);");
+            }
+            else
+            {
+                builder.AppendLine("@else(state);");
             }
         }
 

--- a/src/UnionGeneration/UnionSourceBuilder.cs
+++ b/src/UnionGeneration/UnionSourceBuilder.cs
@@ -1,4 +1,3 @@
-﻿using System.Net.NetworkInformation;
 using System.Text;
 
 namespace Dunet.UnionGeneration;

--- a/src/UnionGeneration/UnionSourceBuilder.cs
+++ b/src/UnionGeneration/UnionSourceBuilder.cs
@@ -130,7 +130,8 @@ internal static class UnionSourceBuilder
         //     ...
         // );
         builder.AppendLine("    public abstract TMatchOutput Match<TState, TMatchOutput>(");
-        builder.AppendLine("        TState state,");
+        builder.Append($"        TState state");
+        builder.AppendLine(union.Variants.Count > 0 ? "," : string.Empty);
         for (int i = 0; i < union.Variants.Count; ++i)
         {
             var variant = union.Variants[i];
@@ -152,7 +153,8 @@ internal static class UnionSourceBuilder
         //     ...
         // );
         builder.AppendLine("    public abstract void Match<TState>(");
-        builder.AppendLine("        TState state,");
+        builder.Append($"        TState state");
+        builder.AppendLine(union.Variants.Count > 0 ? "," : string.Empty);
         for (int i = 0; i < union.Variants.Count; ++i)
         {
             var variant = union.Variants[i];
@@ -218,7 +220,8 @@ internal static class UnionSourceBuilder
             //     System.Func<TState, TMatchOutput> @else
             // );
             builder.AppendLine($"    public abstract TMatchOutput Match{variant.Identifier}<TState, TMatchOutput>(");
-            builder.AppendLine("        TState state,");
+            builder.Append($"        TState state");
+            builder.AppendLine(union.Variants.Count > 0 ? "," : string.Empty);
             builder.Append($"        System.Func<TState, {variant.Identifier}");
             builder.AppendTypeParams(variant.TypeParameters);
             builder.AppendLine($", TMatchOutput> {variant.Identifier.ToMethodParameterCase()},");
@@ -236,7 +239,8 @@ internal static class UnionSourceBuilder
             //     System.Action<TState> @else
             // );
             builder.AppendLine($"    public abstract void Match{variant.Identifier}<TState>(");
-            builder.AppendLine("        TState state,");
+            builder.Append($"        TState state");
+            builder.AppendLine(union.Variants.Count > 0 ? "," : string.Empty);
             builder.Append($"        System.Action<TState, {variant.Identifier}");
             builder.AppendTypeParams(variant.TypeParameters);
             builder.AppendLine($"> {variant.Identifier.ToMethodParameterCase()},");
@@ -302,7 +306,8 @@ internal static class UnionSourceBuilder
         //     ...
         // ) => unionVariantX(state, this);
         builder.AppendLine("        public override TMatchOutput Match<TState, TMatchOutput>(");
-        builder.AppendLine("            TState state,");
+        builder.Append($"        TState state");
+        builder.AppendLine(union.Variants.Count > 0 ? "," : string.Empty);
         for (int i = 0; i < union.Variants.Count; ++i)
         {
             var variantParam = union.Variants[i];
@@ -324,7 +329,8 @@ internal static class UnionSourceBuilder
         //     ...
         // ) => unionVariantX(state, this);
         builder.AppendLine("        public override void Match<TState>(");
-        builder.AppendLine("            TState state,");
+        builder.Append($"        TState state");
+        builder.AppendLine(union.Variants.Count > 0 ? "," : string.Empty);
         for (int i = 0; i < union.Variants.Count; ++i)
         {
             var variantParam = union.Variants[i];
@@ -409,7 +415,8 @@ internal static class UnionSourceBuilder
             builder.AppendLine(
                 $"        public override TMatchOutput Match{specificVariant.Identifier}<TState, TMatchOutput>("
             );
-            builder.AppendLine("            TState state,");
+            builder.Append($"        TState state");
+            builder.AppendLine(union.Variants.Count > 0 ? "," : string.Empty);
             builder.Append($"            System.Func<TState, {specificVariant.Identifier}");
             builder.AppendTypeParams(specificVariant.TypeParameters);
             builder.AppendLine(
@@ -436,7 +443,8 @@ internal static class UnionSourceBuilder
         foreach (var specificVariant in union.Variants)
         {
             builder.AppendLine($"        public override void Match{specificVariant.Identifier}<TState>(");
-            builder.AppendLine("            TState state,");
+            builder.Append($"        TState state");
+            builder.AppendLine(union.Variants.Count > 0 ? "," : string.Empty);
             builder.Append($"            System.Action<TState, {specificVariant.Identifier}");
             builder.AppendTypeParams(specificVariant.TypeParameters);
             builder.AppendLine($"> {specificVariant.Identifier.ToMethodParameterCase()},");

--- a/test/UnionGeneration/MatchMethodWithStateTests.cs
+++ b/test/UnionGeneration/MatchMethodWithStateTests.cs
@@ -1,0 +1,127 @@
+﻿namespace Dunet.Test.UnionGeneration;
+
+public sealed class MatchMethodWithStateTests
+{
+    [Fact]
+    public void CanUseUnionTypesInDedicatedMatchMethod()
+    {
+        // Arrange.
+        var source = """
+using Dunet;
+
+Shape shape = new Shape.Rectangle(3, 4);
+double state = 2d;
+
+var area = shape.Match(
+    state,
+    static (s, circle) => s + 3.14 * circle.Radius * circle.Radius,
+    static (s, rectangle) => s + rectangle.Length * rectangle.Width,
+    static (s, triangle) => s + triangle.Base * triangle.Height / 2
+);
+
+[Union]
+partial record Shape
+{
+    partial record Circle(double Radius);
+    partial record Rectangle(double Length, double Width);
+    partial record Triangle(double Base, double Height);
+}
+""";
+        // Act.
+        var result = Compiler.Compile(source);
+
+        // Assert.
+        using var scope = new AssertionScope();
+        result.CompilationErrors.Should().BeEmpty();
+        result.GenerationErrors.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("Shape shape = new Shape.Rectangle(3, 4);", 14d)]
+    [InlineData("Shape shape = new Shape.Circle(1);", 5.14d)]
+    [InlineData("Shape shape = new Shape.Triangle(4, 2);", 6d)]
+    public void MatchMethodCallsCorrectFunctionArgument(
+        string shapeDeclaration,
+        double expectedArea
+    )
+    {
+        // Arrange.
+        var source = $$"""
+using Dunet;
+
+static double GetArea()
+{
+    {{shapeDeclaration}}
+    double state = 2d;
+    return shape.Match(
+        state,
+        static (s, circle) => s + 3.14 * circle.Radius * circle.Radius,
+        static (s, rectangle) => s + rectangle.Length * rectangle.Width,
+        static (s, triangle) => s + triangle.Base * triangle.Height / 2
+    );
+}
+
+[Union]
+partial record Shape
+{
+    partial record Circle(double Radius);
+    partial record Rectangle(double Length, double Width);
+    partial record Triangle(double Base, double Height);
+}
+""";
+        // Act.
+        var result = Compiler.Compile(source);
+        var actualArea = result.Assembly?.ExecuteStaticMethod<double>("GetArea");
+
+        // Assert.
+        using var scope = new AssertionScope();
+        result.CompilationErrors.Should().BeEmpty();
+        result.GenerationErrors.Should().BeEmpty();
+        actualArea.Should().BeApproximately(expectedArea, 0.0000000001d);
+    }
+
+    [Theory]
+    [InlineData("Keyword keyword = new Keyword.New();" , "string state = \"new\";", "new")]
+    [InlineData("Keyword keyword = new Keyword.Base();", "string state = \"base\";", "base")]
+    [InlineData("Keyword keyword = new Keyword.Null();", "string state = \"null\";", "null")]
+    public void CanMatchOnUnionVariantsNamedAfterKeywords(
+        string keywordDeclaration,
+        string stateDeclaration,
+        string expectedKeyword
+    )
+    {
+        // Arrange.
+        var source = $$"""
+using Dunet;
+
+static string GetKeyword()
+{
+    {{keywordDeclaration}}
+    {{stateDeclaration}}
+    return keyword.Match(
+        state,
+        static (s, @new) => s,
+        static (s, @base) => s,
+        static (s, @null) => s
+    );
+}
+
+[Union]
+partial record Keyword
+{
+    partial record New;
+    partial record Base;
+    partial record Null;
+}
+""";
+        // Act.
+        var result = Compiler.Compile(source);
+        var actualKeyword = result.Assembly?.ExecuteStaticMethod<string>("GetKeyword");
+
+        // Assert.
+        using var scope = new AssertionScope();
+        result.CompilationErrors.Should().BeEmpty();
+        result.GenerationErrors.Should().BeEmpty();
+        actualKeyword.Should().Be(expectedKeyword);
+    }
+}

--- a/test/UnionGeneration/MatchSpecificUnionValueWithStateTests.cs
+++ b/test/UnionGeneration/MatchSpecificUnionValueWithStateTests.cs
@@ -1,0 +1,92 @@
+﻿namespace Dunet.Test.UnionGeneration;
+
+public sealed class MatchSpecificUnionValueWithStateTests
+{
+    [Theory]
+    [InlineData("Shape shape = new Shape.Rectangle(3, 4);", 1d)]
+    [InlineData("Shape shape = new Shape.Circle(1);", 5.14d)]
+    [InlineData("Shape shape = new Shape.Triangle(4, 2);", 1d)]
+    public void SpecificMatchMethodCallsCorrectFunctionArgument(
+        string shapeDeclaration,
+        double expectedArea
+    )
+    {
+        // Arrange.
+        var source = $$"""
+using Dunet;
+
+static double GetArea()
+{
+    {{shapeDeclaration}}
+    double state = 2d;
+    return shape.MatchCircle(
+        state,
+        static (s, circle) => s + 3.14 * circle.Radius * circle.Radius,
+        static s => -1 + s
+    );
+}
+
+[Union]
+partial record Shape
+{
+    partial record Circle(double Radius);
+    partial record Rectangle(double Length, double Width);
+    partial record Triangle(double Base, double Height);
+}
+""";
+        // Act.
+        var result = Compiler.Compile(source);
+        var actualArea = result.Assembly?.ExecuteStaticMethod<double>("GetArea");
+
+        // Assert.
+        using var scope = new AssertionScope();
+        result.CompilationErrors.Should().BeEmpty();
+        result.GenerationErrors.Should().BeEmpty();
+        actualArea.Should().BeApproximately(expectedArea, 0.0000000001d);
+    }
+
+    [Theory]
+    [InlineData("Shape shape = new Shape.Rectangle(3, 4);", 1d)]
+    [InlineData("Shape shape = new Shape.Circle(1);", 1d)]
+    [InlineData("Shape shape = new Shape.Triangle(4, 2);", 6d)]
+    public void SpecificMatchMethodCallsCorrectActionArgument(
+        string shapeDeclaration,
+        double expectedArea
+    )
+    {
+        // Arrange.
+        var source = $$"""
+using Dunet;
+
+static double GetArea()
+{
+    double value = 0d;
+    {{shapeDeclaration}}
+    double state = 2d;
+    shape.MatchTriangle(
+        state,
+        (s, triangle) => { value = s + 0.5 * triangle.Base * triangle.Height; },
+        s => { value = -1 + s; }
+    );
+    return value;
+}
+
+[Union]
+partial record Shape
+{
+    partial record Circle(double Radius);
+    partial record Rectangle(double Length, double Width);
+    partial record Triangle(double Base, double Height);
+}
+""";
+        // Act.
+        var result = Compiler.Compile(source);
+        var actualArea = result.Assembly?.ExecuteStaticMethod<double>("GetArea");
+
+        // Assert.
+        using var scope = new AssertionScope();
+        result.CompilationErrors.Should().BeEmpty();
+        result.GenerationErrors.Should().BeEmpty();
+        actualArea.Should().BeApproximately(expectedArea, 0.0000000001d);
+    }
+}


### PR DESCRIPTION
Hey @domn1995 I have created an implementation that should provide a solution for #121 that generates `Variant` & `Specific` `Match` methods that accept custom state eg:

```csharp
// Variant
public abstract TMatchOutput Match<TState, TMatchOutput>(TState state, ...);
public abstract void `Match<TState>(TState state, ...);

// Specific
public abstract TMatchOutput MatchSpecific<TState, TMatchOutput>(TState state ...);
public abstract void MatchSpecific<TState>(TState state ...);
```

I am also creating this as a draft since I would like some guidance about the tests and implementation.

For the implementation: I implemented the state methods together with the non-state ones but I could also move them to a different method. I just thought they belong together with their non-state counterparts.

For the tests: I know I could change some tests that execute methods to also execute the state counterpart or I could create a new test class that does just that but I am not sure which way to go 😄