### PR TITLE
Avoid CS0436 warning

### DIFF
--- a/src/UnionAttributeGeneration/UnionAttributeSource.cs
+++ b/src/UnionAttributeGeneration/UnionAttributeSource.cs
@@ -15,6 +15,6 @@ namespace Dunet;
 /// Enables dunet union source generation for the decorated partial record.
 /// </summary>
 [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
-public sealed class UnionAttribute : Attribute {}
+internal sealed class UnionAttribute : Attribute {}
 """;
 }


### PR DESCRIPTION
When dunet is used in more than one project in the dependency tree, there is a conflict between multiple definitions of `UnionAttribute`. This *should* fix it, but I haven't tested it.