### PR TITLE
Remove private constructor for abstract union

### DIFF
--- a/src/UnionGeneration/UnionDeclaration.cs
+++ b/src/UnionGeneration/UnionDeclaration.cs
@@ -7,6 +7,7 @@ internal sealed record UnionDeclaration(
     string? Namespace,
     Accessibility Accessibility,
     string Name,
+    bool IsAbstract,
     List<TypeParameter> TypeParameters,
     List<TypeParameterConstraint> TypeParameterConstraints,
     List<VariantDeclaration> Variants,

--- a/src/UnionGeneration/UnionGenerator.cs
+++ b/src/UnionGeneration/UnionGenerator.cs
@@ -118,6 +118,7 @@ public sealed class UnionGenerator : IIncrementalGenerator
                 Namespace: @namespace,
                 Accessibility: recordSymbol.DeclaredAccessibility,
                 Name: recordSymbol.Name,
+                IsAbstract: recordSymbol.IsAbstract,
                 TypeParameters: typeParameters?.ToList() ?? new(),
                 TypeParameterConstraints: typeParameterConstraints?.ToList() ?? new(),
                 Variants: variants.ToList(),

--- a/src/UnionGeneration/UnionSourceBuilder.cs
+++ b/src/UnionGeneration/UnionSourceBuilder.cs
@@ -32,7 +32,10 @@ internal static class UnionSourceBuilder
         builder.AppendTypeParams(union.TypeParameters);
         builder.AppendLine();
         builder.AppendLine("{");
-        builder.AppendLine($"    private {union.Name}() {{}}");
+        if (!union.IsAbstract)
+        {
+            builder.AppendLine($"    private {union.Name}() {{}}");
+        }
         builder.AppendLine();
 
         builder.AppendAbstractMatchMethods(union);

--- a/test/UnionGeneration/GenerationTests.cs
+++ b/test/UnionGeneration/GenerationTests.cs
@@ -207,4 +207,33 @@ partial record Result
         result.CompilationErrors.Should().BeEmpty();
         result.GenerationDiagnostics.Should().BeEmpty();
     }
+
+    [Fact]
+    public void UnionInheritsBaseConstructor()
+    {
+        // Arrange.
+        string programCs = """
+using Dunet;
+using System;
+
+var dog = new Animal.Dog();
+var cat = new Animal.Cat();
+
+public record Entity(Guid Id);
+
+[Union]
+abstract partial record Animal(Guid Id) : Entity(Id)
+{
+    partial record Dog() : Animal(Guid.NewGuid());
+    partial record Cat() : Animal(Guid.NewGuid());
+}
+""";
+        // Act.
+        var result = Compiler.Compile(programCs);
+
+        // Assert.
+        using AssertionScope scope = new();
+        result.CompilationErrors.Should().BeEmpty();
+        result.GenerationDiagnostics.Should().BeEmpty();
+    }
 }


### PR DESCRIPTION
Is it possible to use inheritance if the union is marked abstract? I cannot use the required keyword due to my language version.

```csharp
public record Entity(Guid Id);

[Union]
public abstract partial Animal(Guid Id) : Entity(Id)
{
    public partial record Dog(string Name) : Animal(Guid.NewGuid());
    public partial record Cat(string Name) : Animal(Guid.NewGuid());
}
```

In this example I curious as to whether marking the Union type as abstract could prevent the source generator from auto generating the private default constructor which does not call the base constructor and prevents compiler errors.