### PR TITLE
feat: add incremental caching

### DIFF
--- a/Dunet.sln
+++ b/Dunet.sln
@@ -23,6 +23,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExpressionCalculator", "sam
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExpressionCalculatorWithState", "samples\ExpressionCalculatorWithState\ExpressionCalculatorWithState.csproj", "{943A33D0-FAC8-44B2-9D20-205CA415F940}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dunet.Benchmark", "benchmark\Dunet.Benchmark\Dunet.Benchmark.csproj", "{44A04A62-D495-4450-8C15-2BD67DF5159A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -65,6 +67,10 @@ Global
 		{943A33D0-FAC8-44B2-9D20-205CA415F940}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{943A33D0-FAC8-44B2-9D20-205CA415F940}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{943A33D0-FAC8-44B2-9D20-205CA415F940}.Release|Any CPU.Build.0 = Release|Any CPU
+		{44A04A62-D495-4450-8C15-2BD67DF5159A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{44A04A62-D495-4450-8C15-2BD67DF5159A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{44A04A62-D495-4450-8C15-2BD67DF5159A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{44A04A62-D495-4450-8C15-2BD67DF5159A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/benchmark/Dunet.Benchmark/Dunet.Benchmark.csproj
+++ b/benchmark/Dunet.Benchmark/Dunet.Benchmark.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="BenchmarkDotNet" Version="0.13.7" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\Dunet.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/benchmark/Dunet.Benchmark/Program.cs
+++ b/benchmark/Dunet.Benchmark/Program.cs
@@ -1,0 +1,3 @@
+﻿using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

--- a/benchmark/Dunet.Benchmark/SourceGeneratorBenchmark.cs
+++ b/benchmark/Dunet.Benchmark/SourceGeneratorBenchmark.cs
@@ -1,0 +1,94 @@
+﻿using BenchmarkDotNet.Attributes;
+using Dunet.UnionAttributeGeneration;
+using Dunet.UnionGeneration;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using System.Reflection;
+
+namespace Dunet.Benchmark;
+
+[MemoryDiagnoser]
+[InProcess]
+public class SourceGeneratorBenchmarks
+{
+    private const string SourceText =
+        """
+        using Dunet;
+
+        [Union]
+        public partial record Expression
+        {
+            partial record Number(int Value);
+
+            partial record Add(Expression Left, Expression Right);
+
+            partial record Multiply(Expression Left, Expression Right);
+
+            partial record Variable(string Value);
+        }
+
+        [Union]
+        partial record Shape
+        {
+            partial record Circle(double Radius);
+
+            partial record Rectangle(double Length, double Width);
+
+            partial record Triangle(double Base, double Height);
+        }
+
+        [Union]
+        public partial record Option<T>
+        {
+            public static implicit operator Option<T>(T value) => new Some(value);
+
+            partial record Some(T Value);
+
+            partial record None();
+        }
+        """;
+        
+    private GeneratorDriver? _driver;
+    private Compilation? _compilation;
+
+    private (Compilation, CSharpGeneratorDriver) Setup(string sourceText)
+    {
+        var compilation = CreateCompilation(sourceText);
+        if (compilation == null)
+            throw new InvalidOperationException("Compilation returned null");
+
+        var unionGenerator = new UnionGenerator();
+        var unionAttributeGenerator = new UnionAttributeGenerator();
+
+        var driver = CSharpGeneratorDriver.Create(unionGenerator, unionAttributeGenerator);
+        
+        return (compilation, driver);
+    }
+
+    [GlobalSetup(Target = nameof(Compile))]
+    public void SetupCompile() => (_compilation, _driver) = Setup(SourceText);
+    
+    [GlobalSetup(Target = nameof(Cached))]
+    public void SetupCached()
+    {
+        (_compilation, var driver) = Setup(SourceText);
+        _driver = driver.RunGenerators(_compilation);
+    }
+
+    [Benchmark]
+    public GeneratorDriver Compile() => _driver!.RunGeneratorsAndUpdateCompilation(_compilation!, out _, out _);
+    
+    [Benchmark]
+    public GeneratorDriver Cached() => _driver!.RunGeneratorsAndUpdateCompilation(_compilation!, out _, out _);
+
+    private static Compilation CreateCompilation(params string[] sources) =>
+        CSharpCompilation.Create(
+            "compilation",
+            sources.Select(static source => CSharpSyntaxTree.ParseText(source)),
+            new[]
+            {
+                MetadataReference.CreateFromFile(typeof(Binder).GetTypeInfo().Assembly.Location)
+            },
+            new CSharpCompilationOptions(OutputKind.ConsoleApplication)
+        );
+}

--- a/src/UnionGeneration/ImmutableEquatableArray.cs
+++ b/src/UnionGeneration/ImmutableEquatableArray.cs
@@ -1,0 +1,88 @@
+﻿namespace Dunet.UnionGeneration;
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+public static class ImmutableEquatableArray
+{
+    public static ImmutableEquatableArray<T> Empty<T>()
+        where T : IEquatable<T> => ImmutableEquatableArray<T>.Empty;
+
+    public static ImmutableEquatableArray<T> ToImmutableEquatableArray<T>(this IEnumerable<T> values)
+        where T : IEquatable<T> => new(values);
+}
+
+/// <summary>
+/// Provides an immutable list implementation which implements sequence equality.
+/// </summary>
+public sealed class ImmutableEquatableArray<T> : IEquatable<ImmutableEquatableArray<T>>, IReadOnlyList<T>
+    where T : IEquatable<T>
+{
+    public static ImmutableEquatableArray<T> Empty { get; } = new(Array.Empty<T>());
+
+    private readonly T[] _values;
+    public T this[int index] => _values[index];
+    public int Count => _values.Length;
+
+    public ImmutableEquatableArray(IEnumerable<T> values) => _values = values.ToArray();
+
+    public bool Equals(ImmutableEquatableArray<T>? other) =>
+        other != null && ((ReadOnlySpan<T>)_values).SequenceEqual(other._values);
+
+    public override bool Equals(object? obj) => obj is ImmutableEquatableArray<T> other && Equals(other);
+
+    public override int GetHashCode()
+    {
+        var hash = 0;
+        foreach (T value in _values)
+        {
+            hash = Combine(hash, value.GetHashCode());
+        }
+
+        static int Combine(int h1, int h2)
+        {
+            // RyuJIT optimizes this to use the ROL instruction
+            // Related GitHub pull request: https://github.com/dotnet/coreclr/pull/1830
+            uint rol5 = ((uint)h1 << 5) | ((uint)h1 >> 27);
+            return ((int)rol5 + h1) ^ h2;
+        }
+
+        return hash;
+    }
+
+    public Enumerator GetEnumerator() => new(_values);
+
+    IEnumerator<T> IEnumerable<T>.GetEnumerator() => ((IEnumerable<T>)_values).GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => _values.GetEnumerator();
+
+    public struct Enumerator
+    {
+        private readonly T[] _values;
+        private int _index;
+
+        internal Enumerator(T[] values)
+        {
+            _values = values;
+            _index = -1;
+        }
+
+        public bool MoveNext()
+        {
+            var newIndex = _index + 1;
+
+            if ((uint)newIndex < (uint)_values.Length)
+            {
+                _index = newIndex;
+                return true;
+            }
+
+            return false;
+        }
+
+        public readonly T Current => _values[_index];
+    }
+}
+

--- a/src/UnionGeneration/RecordDeclarationSyntaxParser.cs
+++ b/src/UnionGeneration/RecordDeclarationSyntaxParser.cs
@@ -27,7 +27,7 @@ internal static class RecordDeclarationSyntaxParser
     /// </summary>
     /// <param name="record">This record declaration.</param>
     /// <returns>The sequence of type parameter constraints, if any. Otherwise, <see langword="null"/>.</returns>
-    public static IEnumerable<TypeParameterConstraint>? GetTypeParameterConstraints(
+    public static IEnumerable<TypeParameterConstraint> GetTypeParameterConstraints(
         this RecordDeclarationSyntax record
     ) =>
         record.ConstraintClauses.Select(
@@ -100,8 +100,8 @@ internal static class RecordDeclarationSyntaxParser
                     new VariantDeclaration()
                     {
                         Identifier = nestedRecord.Identifier.ToString(),
-                        TypeParameters = nestedRecord.GetTypeParameters()?.ToList() ?? new(),
-                        Parameters = nestedRecord.GetParameters(semanticModel)?.ToList() ?? new()
+                        TypeParameters = nestedRecord.GetTypeParameters()?.ToImmutableEquatableArray() ?? ImmutableEquatableArray.Empty<TypeParameter>(),
+                        Parameters = nestedRecord.GetParameters(semanticModel)?.ToImmutableEquatableArray() ?? ImmutableEquatableArray.Empty<Parameter>(),
                     }
             );
 
@@ -165,7 +165,7 @@ internal static class RecordDeclarationSyntaxParser
 
         var parentSymbol = semanticModel.GetDeclaredSymbol(parent);
 
-        // Ignore top level statement synthentic program class.
+        // Ignore top level statement synthetic program class.
         if (parentSymbol?.ToDisplayString() is null or "<top-level-statements-entry-point>")
         {
             return;

--- a/src/UnionGeneration/UnionDeclaration.cs
+++ b/src/UnionGeneration/UnionDeclaration.cs
@@ -3,15 +3,15 @@
 namespace Dunet.UnionGeneration;
 
 internal sealed record UnionDeclaration(
-    List<string> Imports,
+    ImmutableEquatableArray<string> Imports,
     string? Namespace,
     Accessibility Accessibility,
     string Name,
-    List<TypeParameter> TypeParameters,
-    List<TypeParameterConstraint> TypeParameterConstraints,
-    List<VariantDeclaration> Variants,
-    Stack<ParentType> ParentTypes,
-    List<Property> Properties
+    ImmutableEquatableArray<TypeParameter> TypeParameters,
+    ImmutableEquatableArray<TypeParameterConstraint> TypeParameterConstraints,
+    ImmutableEquatableArray<VariantDeclaration> Variants,
+    ImmutableEquatableArray<ParentType> ParentTypes,
+    ImmutableEquatableArray<Property> Properties
 )
 {
     // Extension methods cannot be generated for a union declared in a top level program (no namespace).
@@ -51,8 +51,8 @@ internal sealed record UnionDeclaration(
 internal sealed record VariantDeclaration
 {
     public required string Identifier { get; init; }
-    public required List<TypeParameter> TypeParameters { get; init; }
-    public required List<Parameter> Parameters { get; init; }
+    public required ImmutableEquatableArray<TypeParameter> TypeParameters { get; init; }
+    public required ImmutableEquatableArray<Parameter> Parameters { get; init; }
 }
 
 internal sealed record TypeParameter(string Identifier)


### PR DESCRIPTION
Hey, big fan of your library. It's super intuitive and reminds me of rusts enums, I hope C# has this added one day 😄 

Adds incremental caching and benchmarks. Used `ImmutableEquatableArray` to make `UnionDeclaration` equtable.

### Results
|  Method |       Mean |    Error |   StdDev |     Gen0 |    Gen1 | Allocated |
|-------- |-----------:|---------:|---------:|---------:|--------:|----------:|
| Compile | 1,074.8 us | 21.44 us | 27.88 us | 195.3125 | 35.1563 | 380.21 KB |
|  Cached |   556.8 us |  4.75 us |  3.96 us |  48.8281 |       - |  74.99 KB |