### PR TITLE
Add v1.11.0 Migration guide

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -450,3 +450,25 @@ var variant1 = new Parent1.Parent2.Nested.Variant1();
 - [Web Client](./samples/PokemonClient/PokeClient.cs)
 - [Recursive Expressions](./samples/ExpressionCalculator/Program.cs)
 - [Recursive Expressions with Stateful Matching](./samples/ExpressionCalculatorWithState/Program.cs)
+
+## Migration
+
+### < 1.11.0 to >= 1.11.0
+
+From v1.11.0 this library now contains an assembly reference.
+
+By default before this `dotnet add package dunet` will have generated:
+```xml
+<PackageReference Include="dunet" Version="1.10.0">
+    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PrivateAssets>all</PrivateAssets>
+</PackageReference>
+```
+
+When upgrading to dunet v1.11.0, this will need to be simplified to:
+```xml
+<PackageReference Include="dunet" Version="1.11.0" />
+```
+
+Otherwise the assembly will not be included for compilation, leading to build failures when trying to reference
+ the `Dunet` namespace or the `UnionAttribute` class.

--- a/Readme.md
+++ b/Readme.md
@@ -453,7 +453,7 @@ var variant1 = new Parent1.Parent2.Nested.Variant1();
 
 ## Migration
 
-### < 1.11.0 to >= 1.11.0
+### Migrating from versions < 1.11.0 to versions >= 1.11.0
 
 From v1.11.0 this library now contains an assembly reference.
 


### PR DESCRIPTION
Adds a migration guide for Dunet < 1.11.0 to 1.11.0.

This is based on my experience updating a couple of projects.

Not sure if we want to add this in the Readme.md, or start a `/docs/changelog.md` or `/docs/migrations/v1.11.0.md`. 
Those might be a bit overbuilt for now, but thought I'd open this to discuss.