### PR TITLE
feat: generate static factory methods for variants

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0",
+    "rollForward": "minor"
+  }
+}

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0",
+    "version": "8.0.0",
     "rollForward": "minor"
   }
 }

--- a/src/Dunet.Generator/UnionGeneration/UnionSourceBuilder.cs
+++ b/src/Dunet.Generator/UnionGeneration/UnionSourceBuilder.cs
@@ -560,8 +560,6 @@ internal static class UnionSourceBuilder
             builder.AppendLine($"({string.Join(", ", constructorCallParameters)});");
         }
 
-        // TODO(jupjohn): note in PR about static non-generic class factory methods for generic unions
-        // e.g. Union<string>.AsThing("abc") v.s. Union.AsThing("abc) (generic type inferred)
         return builder;
     }
 }

--- a/src/Dunet.Generator/UnionGeneration/UnionSourceBuilder.cs
+++ b/src/Dunet.Generator/UnionGeneration/UnionSourceBuilder.cs
@@ -528,7 +528,7 @@ internal static class UnionSourceBuilder
     {
         foreach (var variant in union.Variants)
         {
-            // public static Union AsUnionVariantX(
+            // public static Union OfUnionVariantX(
             //     T1 t1,
             //     T2 t2,
             //     ...
@@ -540,7 +540,7 @@ internal static class UnionSourceBuilder
             builder.AppendLine();
             builder.Append($"    public static {union.Name}");
             builder.AppendTypeParams(union.TypeParameters);
-            builder.AppendLine($" As{variant.Identifier}(");
+            builder.AppendLine($" Of{variant.Identifier}(");
 
             FactoryProperty[] allProperties = [..variantProperties, ..unionProperties];
             for (var index = 0; index < allProperties.Length; index++)

--- a/src/Dunet.Generator/UnionGeneration/UnionSourceBuilder.cs
+++ b/src/Dunet.Generator/UnionGeneration/UnionSourceBuilder.cs
@@ -68,6 +68,47 @@ internal static class UnionSourceBuilder
             builder.AppendLine("    }");
         }
 
+        // TODO(jupjohn): extract this out to an extension method
+        // TODO(jupjohn): prelim struct support
+        foreach (var variant in union.Variants)
+        {
+            builder.AppendLine();
+
+            var methodParameters = string.Empty;
+            var constructorParameters = string.Empty;
+
+            if (variant.Parameters.Count > 0)
+            {
+                // TODO(jupjohn): I don't like this
+                var parameters = variant.Parameters
+                    .Select(p => (
+                        Type: p.Type.Identifier,
+                        Property: p.Identifier,
+                        // PropertyName -> propertyName
+                        Parameter: $"{char.ToLower(p.Identifier[0])}{p.Identifier[1..]}"
+                    ))
+                    .ToArray();
+                methodParameters = string.Join(", ", parameters.Select(p => $"{p.Type} {p.Parameter}"));
+                constructorParameters = string.Join(", ", parameters.Select(p => $"{p.Property}: {p.Parameter}"));
+            }
+
+            builder.Append($"    public static {union.Name}");
+            builder.AppendTypeParams(union.TypeParameters);
+            builder.Append($" As{variant.Identifier}");
+            builder.AppendLine($"({methodParameters})");
+
+            builder.AppendLine("    {");
+            builder.Append("        return ");
+            builder.Append($"new {variant.Identifier}");
+            builder.AppendTypeParams(variant.TypeParameters);
+            builder.Append($"({constructorParameters})");
+            builder.AppendLine(";");
+            builder.AppendLine("    }");
+        }
+
+        // TODO(jupjohn): note in PR about static non-generic class factory methods for generic unions
+        // e.g. Union<string>.AsThing("abc") v.s. Union.AsThing("abc) (generic type inferred)
+
         builder.AppendLine("}");
 
         foreach (var _ in parentTypes)

--- a/src/Dunet.Generator/UnionGeneration/UnionSourceBuilder.cs
+++ b/src/Dunet.Generator/UnionGeneration/UnionSourceBuilder.cs
@@ -528,7 +528,7 @@ internal static class UnionSourceBuilder
         {
             // public static Union AsUnionVariantX(T1 t1, T2 t2, ...)
             // {
-            //     return new Union.UnionVariantX(t1, t2, ...);
+            //     return new UnionVariantX(t1, t2, ...);
             // }
 
             var methodParameters = string.Empty;
@@ -552,15 +552,12 @@ internal static class UnionSourceBuilder
             builder.AppendLine();
             builder.Append($"    public static {union.Name}");
             builder.AppendTypeParams(union.TypeParameters);
-            builder.Append($" As{variant.Identifier}");
-            builder.AppendLine($"({methodParameters})");
+            builder.AppendLine($" As{variant.Identifier}({methodParameters})");
 
             builder.AppendLine("    {");
-            builder.Append("        return ");
-            builder.Append($"new {variant.Identifier}");
+            builder.Append($"        return new {variant.Identifier}");
             builder.AppendTypeParams(variant.TypeParameters);
-            builder.Append($"({constructorParameters})");
-            builder.AppendLine(";");
+            builder.AppendLine($"({constructorParameters});");
             builder.AppendLine("    }");
         }
 

--- a/src/Dunet.Generator/UnionGeneration/UnionSourceBuilder.cs
+++ b/src/Dunet.Generator/UnionGeneration/UnionSourceBuilder.cs
@@ -3,6 +3,8 @@ using Microsoft.CodeAnalysis.CSharp;
 
 namespace Dunet.Generator.UnionGeneration;
 
+using FactoryProperty = (string Type, string Property, string Parameter);
+
 internal static class UnionSourceBuilder
 {
     public static string Build(UnionDeclaration union)
@@ -540,7 +542,7 @@ internal static class UnionSourceBuilder
             builder.AppendTypeParams(union.TypeParameters);
             builder.AppendLine($" As{variant.Identifier}(");
 
-            (string PropertyType, string PropertyIdentifier, string ParameterIdentifier)[] allProperties = [..variantProperties, ..unionProperties];
+            FactoryProperty[] allProperties = [..variantProperties, ..unionProperties];
             for (var index = 0; index < allProperties.Length; index++)
             {
                 var parameterSeparator = index != allProperties.Length - 1 ? "," : string.Empty;
@@ -573,8 +575,7 @@ internal static class UnionSourceBuilder
 
         return builder;
 
-        static IEnumerable<(string Type, string Property, string Parameter)>
-            ExtractParameters(IEnumerable<Parameter> parameters)
+        static IEnumerable<FactoryProperty> ExtractParameters(IEnumerable<Parameter> parameters)
         {
             return parameters
                 .Select(p => (

--- a/src/Dunet.Generator/UnionGeneration/UnionSourceBuilder.cs
+++ b/src/Dunet.Generator/UnionGeneration/UnionSourceBuilder.cs
@@ -525,10 +525,11 @@ internal static class UnionSourceBuilder
     {
         foreach (var variant in union.Variants)
         {
-            // public static Union AsUnionVariantX(T1 t1, T2 t2, ...)
-            // {
-            //     return new UnionVariantX(t1, t2, ...);
-            // }
+            // public static Union AsUnionVariantX(
+            //     T1 t1,
+            //     T2 t2,
+            //     ...
+            // ) => UnionVariantX(t1, t2, ...);
 
             var variantProperties =
                 variant.Parameters

--- a/src/Dunet.Generator/UnionGeneration/UnionSourceBuilder.cs
+++ b/src/Dunet.Generator/UnionGeneration/UnionSourceBuilder.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace Dunet.Generator.UnionGeneration;
 
@@ -539,6 +540,15 @@ internal static class UnionSourceBuilder
                         // PropertyName -> propertyName
                         ParameterIdentifier: $"{char.ToLower(p.Identifier[0])}{p.Identifier[1..]}"
                     ))
+                    .Select(p =>
+                    {
+                        if (SyntaxFacts.GetKeywordKind(p.ParameterIdentifier) != SyntaxKind.None)
+                        {
+                            p.ParameterIdentifier += "Value";
+                        }
+
+                        return p;
+                    })
                     .ToArray();
 
             builder.AppendLine();

--- a/src/Dunet.Generator/UnionGeneration/UnionSourceBuilder.cs
+++ b/src/Dunet.Generator/UnionGeneration/UnionSourceBuilder.cs
@@ -523,7 +523,6 @@ internal static class UnionSourceBuilder
         UnionDeclaration union
     )
     {
-        // TODO(jupjohn): prelim struct support
         foreach (var variant in union.Variants)
         {
             // public static Union AsUnionVariantX(T1 t1, T2 t2, ...)

--- a/test/UnionGeneration/FactoryMethodTests.cs
+++ b/test/UnionGeneration/FactoryMethodTests.cs
@@ -55,4 +55,31 @@ public class FactoryMethodTests
         result.CompilationErrors.Should().BeEmpty();
         result.GenerationDiagnostics.Should().BeEmpty();
     }
+
+    [Fact]
+    public void KeywordsNamedProperties()
+    {
+        var programCs = """
+            using Dunet;
+            using System;
+
+            Result success = Result.AsInner1("base", "string");
+            Result error = Result.AsInner2("class");
+
+            [Union]
+            partial record Result
+            {
+                partial record Inner1(string Base, string String);
+                partial record Inner2(string Class);
+            }
+            """;
+
+        // Act.
+        var result = Compiler.Compile(programCs);
+
+        // Assert.
+        using var scope = new AssertionScope();
+        result.CompilationErrors.Should().BeEmpty();
+        result.GenerationDiagnostics.Should().BeEmpty();
+    }
 }

--- a/test/UnionGeneration/FactoryMethodTests.cs
+++ b/test/UnionGeneration/FactoryMethodTests.cs
@@ -1,0 +1,58 @@
+namespace Dunet.Test.UnionGeneration;
+
+public class FactoryMethodTests
+{
+    [Fact]
+    public void NonGenericFactoryMethods()
+    {
+        var programCs = """
+            using Dunet;
+            using System;
+
+            Result success = Result.AsSuccess("Hello, world!");
+            Result error = Result.AsFailure(new Exception("Boom!"), "Something went wrong :(");
+
+            [Union]
+            partial record Result
+            {
+                partial record Success(string Value);
+                partial record Failure(Exception Error, string Reason);
+            }
+            """;
+
+        // Act.
+        var result = Compiler.Compile(programCs);
+
+        // Assert.
+        using var scope = new AssertionScope();
+        result.CompilationErrors.Should().BeEmpty();
+        result.GenerationDiagnostics.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GenericFactoryMethods()
+    {
+        var programCs = """
+            using Dunet;
+            using System;
+
+            Result<string> success = Result<string>.AsSuccess("Hello, world!");
+            Result<string> error = Result<string>.AsFailure(new Exception("Boom!"), "Something went wrong :(");
+
+            [Union]
+            partial record Result<T>
+            {
+                partial record Success(T Value);
+                partial record Failure(Exception Error, string Reason);
+            }
+            """;
+
+        // Act.
+        var result = Compiler.Compile(programCs);
+
+        // Assert.
+        using var scope = new AssertionScope();
+        result.CompilationErrors.Should().BeEmpty();
+        result.GenerationDiagnostics.Should().BeEmpty();
+    }
+}

--- a/test/UnionGeneration/FactoryMethodTests.cs
+++ b/test/UnionGeneration/FactoryMethodTests.cs
@@ -9,8 +9,8 @@ public class FactoryMethodTests
             using Dunet;
             using System;
 
-            Result success = Result.AsSuccess("Hello, world!");
-            Result error = Result.AsFailure(new Exception("Boom!"), "Something went wrong :(");
+            Result success = Result.OfSuccess("Hello, world!");
+            Result error = Result.OfFailure(new Exception("Boom!"), "Something went wrong :(");
 
             [Union]
             partial record Result
@@ -36,8 +36,8 @@ public class FactoryMethodTests
             using Dunet;
             using System;
 
-            Result<string> success = Result<string>.AsSuccess("Hello, world!");
-            Result<string> error = Result<string>.AsFailure(new Exception("Boom!"), "Something went wrong :(");
+            Result<string> success = Result<string>.OfSuccess("Hello, world!");
+            Result<string> error = Result<string>.OfFailure(new Exception("Boom!"), "Something went wrong :(");
 
             [Union]
             partial record Result<T>
@@ -63,8 +63,8 @@ public class FactoryMethodTests
             using Dunet;
             using System;
 
-            Result success = Result.AsInner1("base", "string");
-            Result error = Result.AsInner2("class");
+            Result success = Result.OfInner1("base", "string");
+            Result error = Result.OfInner2("class");
 
             [Union]
             partial record Result
@@ -90,8 +90,8 @@ public class FactoryMethodTests
             using Dunet;
             using System;
 
-            Result success = Result.AsInner1("base", "string", "name");
-            Result error = Result.AsInner2("class", "name");
+            Result success = Result.OfInner1("base", "string", "name");
+            Result error = Result.OfInner2("class", "name");
 
             [Union]
             partial record Result

--- a/test/UnionGeneration/FactoryMethodTests.cs
+++ b/test/UnionGeneration/FactoryMethodTests.cs
@@ -82,4 +82,32 @@ public class FactoryMethodTests
         result.CompilationErrors.Should().BeEmpty();
         result.GenerationDiagnostics.Should().BeEmpty();
     }
+
+    [Fact]
+    public void ParentLevelProperties()
+    {
+        var programCs = """
+            using Dunet;
+            using System;
+
+            Result success = Result.AsInner1("base", "string", "name");
+            Result error = Result.AsInner2("class", "name");
+
+            [Union]
+            partial record Result
+            {
+                public required string Name { get; init; }
+                partial record Inner1(string Base, string String);
+                partial record Inner2(string Class);
+            }
+            """;
+
+        // Act.
+        var result = Compiler.Compile(programCs);
+
+        // Assert.
+        using var scope = new AssertionScope();
+        result.CompilationErrors.Should().BeEmpty();
+        result.GenerationDiagnostics.Should().BeEmpty();
+    }
 }


### PR DESCRIPTION
This PR aims to generate static factory methods to allow for instantiation without `new`ing up union variants.

Example (stolen from my tests):
```csharp
using Dunet;
using System;

Result success = Result.OfSuccess("Hello, world!");
Result error = Result.OfFailure(new Exception("Boom!"), "Something went wrong :(");

[Union]
partial record Result
{
    partial record Success(string Value);
    partial record Failure(Exception Error, string Reason);
}
```

NOTE: I did include a `global.json` file in this PR to pin the .NET SDK to 8. Shouldn't make any difference to the SDK you're using, I just noticed it was missing as I pin my parent directory's SDK to 6.

Implements #12.