### PR TITLE
Fix tool restoring for csharpier

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -5,7 +5,7 @@
     "csharpier": {
       "version": "1.0.1",
       "commands": [
-        "dotnet-csharpier"
+        "csharpier"
       ]
     }
   }


### PR DESCRIPTION
It seems that the automatic update from `csharpier ` over `dependabot` broke the tool restore.
The breaking change happend from csharper version `0.30.6` to `1.0.0`.

This fixes the config so that the normal `dotnet tool restore` works again.