### PR TITLE
bugfix: nested unions with same name and namespace

### DIFF
--- a/src/Dunet.Generator/UnionGeneration/UnionGenerator.cs
+++ b/src/Dunet.Generator/UnionGeneration/UnionGenerator.cs
@@ -43,8 +43,14 @@ public sealed class UnionGenerator : IIncrementalGenerator
         }
 
         var union = UnionSourceBuilder.Build(unionRecord);
+
+        var unionNameWithParents = string.Join(
+            ".",
+            unionRecord.ParentTypes.Select(x => x.Identifier).Append(unionRecord.Name)
+        );
+
         context.AddSource(
-            $"{unionRecord.Namespace}.{unionRecord.Name}{unionRecord.TypeParameters.Count}.g.cs",
+            $"{unionRecord.Namespace}.{unionNameWithParents}{unionRecord.TypeParameters.Count}.g.cs",
             SourceText.From(union, Encoding.UTF8)
         );
 
@@ -57,7 +63,7 @@ public sealed class UnionGenerator : IIncrementalGenerator
         {
             var matchExtensions = UnionExtensionsSourceBuilder.GenerateExtensions(unionRecord);
             context.AddSource(
-                $"{unionRecord.Namespace}.{unionRecord.Name}{unionRecord.TypeParameters.Count}MatchExtensions.g.cs",
+                $"{unionRecord.Namespace}.{unionNameWithParents}{unionRecord.TypeParameters.Count}MatchExtensions.g.cs",
                 SourceText.From(matchExtensions, Encoding.UTF8)
             );
         }

--- a/test/UnionGeneration/NestedGenerationTests.cs
+++ b/test/UnionGeneration/NestedGenerationTests.cs
@@ -195,4 +195,69 @@ public sealed class NestedGenerationTests
         result.Errors.Should().BeEmpty();
         result.Warnings.Should().BeEmpty();
     }
+
+    [Fact]
+    public async Task CanReturnMultipleNestedVariantsWithSameName()
+    {
+        // Arrange.
+        var programCs =
+            //lang=cs
+            """
+            using Dunet;
+
+            var foo1 = Parent1.Foo();
+            var bar1 = Parent1.Bar();
+            
+            var foo2 = Parent2.Foo();
+            var bar2 = Parent2.Bar();
+
+            public partial class Parent1
+            {
+                [Union]
+                public partial record Nested
+                {
+                    public partial record Variant1;
+                    public partial record Variant2;
+                }
+
+                public static Nested Foo()
+                {
+                    return new Nested.Variant1();
+                }
+
+                public static Nested Bar()
+                {
+                    return new Nested.Variant2();
+                }
+            }
+            
+            public partial class Parent2
+            {
+                [Union]
+                public partial record Nested
+                {
+                    public partial record Variant1;
+                    public partial record Variant2;
+                }
+            
+                public static Nested Foo()
+                {
+                    return new Nested.Variant1();
+                }
+            
+                public static Nested Bar()
+                {
+                    return new Nested.Variant2();
+                }
+            }
+            """;
+
+        // Act.
+        var result = await Compiler.CompileAsync(programCs);
+
+        // Assert.
+        using var scope = new AssertionScope();
+        result.Errors.Should().BeEmpty();
+        result.Warnings.Should().BeEmpty();
+    }
 }


### PR DESCRIPTION
I encountered a case where Dunet stops working in a whole project

I reproduced it in the unit test and fixed it